### PR TITLE
proposal return Object from custom hooks API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jimeng-react-snippets",
   "displayName": "JimengIO React Snippets",
   "description": "Shared snippets used inside Jimeng FE team",
-  "version": "0.1.8",
+  "version": "0.1.9-a1",
   "publisher": "chenyong",
   "engines": {
     "vscode": "^1.33.0"

--- a/snippets.json
+++ b/snippets.json
@@ -150,7 +150,7 @@
       "  // Controller",
       "  let onEdit = () => {",
       "  }",
-      "  return [ui, onEdit] as [ReactNode, typeof onEdit]",
+      "  return { ui, onEdit };",
       "}"
     ]
   }


### PR DESCRIPTION
简化书写和扩展性的考虑. 对象的话, 没有顺序问题, 也不需要手动再定义类型了. 不足的地方是官方的 Hooks 大都用数组, 这样挺不规范的.